### PR TITLE
Add to message, fix spacing.

### DIFF
--- a/lib/cell.rb
+++ b/lib/cell.rb
@@ -25,7 +25,7 @@ attr_reader :coordinate,
     end
   end
   
-  def fire_upon #I had to refactor this to accomodate the render method
+  def fire_upon
     if @fired_upon == false && self.empty?
       @fired_upon = true
     elsif @fired_upon == false && self.empty? == false

--- a/lib/game.rb
+++ b/lib/game.rb
@@ -1,6 +1,6 @@
 require './lib/cpu_placement'
 require './lib/turn'
-# attr_reader :cpu_board, :player_board
+
 class Game
   attr_reader :cpu_board,
               :player_board
@@ -31,7 +31,6 @@ class Game
     end
   end
   
-
   def start_game
     @cpu_placement_cruiser.cpu_placement
     @cpu_placement_submarine.cpu_placement
@@ -64,7 +63,7 @@ class Game
       turn = Turn.new(@cpu_board, @player_board)
       turn.start_turn
     else 
-      p "Those are invalid coordinates. Please try again:"
+      p "Those are invalid coordinates. Please try again (eg: B1 B2):"
       place_player_sub
     end
   end

--- a/lib/turn.rb
+++ b/lib/turn.rb
@@ -41,7 +41,9 @@ class Turn
       p "Please enter a valid coordinate"
       player_shot
     end
+    p "Computer's Board"
     @cpu_board.render
+    p "Player's Board"
     @player_board.render(true)
     cpu_shot
   end
@@ -71,7 +73,9 @@ class Turn
     boolean_array = []
     @player_board.ship.each { |ship| boolean_array << ship.sunk? }
     if boolean_array.all?(true)
+      p "Computer's Board"
       @cpu_board.render
+      p "Player's Board"
       @player_board.render(true)
       puts "CPU won!"
       game = Game.new
@@ -84,7 +88,9 @@ class Turn
     boolean_array = []
     @cpu_board.ship.each { |ship| boolean_array << ship.sunk? }
     if boolean_array.all?(true)
+      p "Computer's Board"
       @cpu_board.render
+      p "Player's Board"
       @player_board.render(true)
       puts "You won!"
       game = Game.new

--- a/spec/cell_spec.rb
+++ b/spec/cell_spec.rb
@@ -124,7 +124,3 @@ RSpec.describe Cell do
     end
   end
 end
-
-
-
-

--- a/spec/game_spec.rb
+++ b/spec/game_spec.rb
@@ -8,10 +8,5 @@ RSpec.describe do
       expect(game).to be_a(Game)
       game.start
     end
-    xit 'says Welcome to Battleship' do
-      game = Game.new
-      # require 'pry'; binding.pry
-      #game.start
-    end
   end
 end


### PR DESCRIPTION
I added labels to cpu.board.render and player board render. So it says "Computer's board" and "Players board" above the new renders that we added right before that last push. Also added (eg: B1 B2) next to invalid coordinates when placing the submarine like you have for placing the cruiser. 